### PR TITLE
WIP: Add USE_ORIGINAL_AFTER clause

### DIFF
--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLLexer.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLLexer.g4
@@ -215,7 +215,7 @@ UPDATE:                          U P D A T E;
 UPDATETEXT:                      U P D A T E T E X T;
 USE:                             U S E;
 USER:                            U S E R;
-USE_ORIGINAL_AFTER:              U S E _ O R I G I N A L _ A F T E R;
+USE_ORIGINAL_AFTER:              U S E '_' O R I G I N A L '_' A F T E R;
 VALUES:                          V A L U E S;
 VARYING:                         V A R Y I N G;
 VIEW:                            V I E W;

--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLLexer.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLLexer.g4
@@ -215,6 +215,7 @@ UPDATE:                          U P D A T E;
 UPDATETEXT:                      U P D A T E T E X T;
 USE:                             U S E;
 USER:                            U S E R;
+USE_ORIGINAL_AFTER:              U S E _ O R I G I N A L _ A F T E R;
 VALUES:                          V A L U E S;
 VARYING:                         V A R Y I N G;
 VIEW:                            V I E W;

--- a/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
+++ b/src/main/antlr4/org/verdictdb/parser/VerdictSQLParser.g4
@@ -168,7 +168,7 @@ ddl_clause
 
 // https://msdn.microsoft.com/en-us/library/ms189499.aspx
 select_statement
-    : with_expression? EXACT? query_expression order_by_clause? limit_clause? ';'?
+    : with_expression? EXACT? query_expression order_by_clause? limit_clause? use_original_after_clause? ';'?
     ;
 
 stream_select_statement
@@ -426,6 +426,9 @@ limit_clause
     : LIMIT number
     ;
 
+use_original_after_clause
+    : USE_ORIGINAL_AFTER number
+    ;
 
 // https://msdn.microsoft.com/en-us/library/ms188385.aspx
 order_by_clause

--- a/src/main/java/org/verdictdb/connection/DbmsQueryResult.java
+++ b/src/main/java/org/verdictdb/connection/DbmsQueryResult.java
@@ -32,6 +32,8 @@ import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
 
+import org.verdictdb.core.querying.ola.HyperTableCube;
+
 /**
  * Represents the results returned from the underlying database.
  *

--- a/src/main/java/org/verdictdb/connection/DbmsQueryResultMetaData.java
+++ b/src/main/java/org/verdictdb/connection/DbmsQueryResultMetaData.java
@@ -20,6 +20,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.verdictdb.core.querying.ola.HyperTableCube;
+
 public class DbmsQueryResultMetaData implements Serializable {
 
   private static final long serialVersionUID = 472824664812257672L;

--- a/src/main/java/org/verdictdb/connection/DbmsQueryResultMetaData.java
+++ b/src/main/java/org/verdictdb/connection/DbmsQueryResultMetaData.java
@@ -40,6 +40,8 @@ public class DbmsQueryResultMetaData implements Serializable {
 
   public List<Boolean> isAggregate = new ArrayList<>();
 
+  public List<HyperTableCube> coveredCubes = new ArrayList<>();
+
   public DbmsQueryResultMetaData() {}
 
 }

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -163,7 +163,7 @@ public class ExecutionContext {
 
     if (queryType.equals(QueryType.select)) {
       log.debug("Query type: select");
-      return sqlSelectQuery(query, getResult);
+      return sqlSelectQuery(query, getResult, false);
     }
 
     // for other types of queries, we invalidate cached metadata for expected data

--- a/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
+++ b/src/main/java/org/verdictdb/coordinator/ExecutionContext.java
@@ -397,7 +397,7 @@ public class ExecutionContext {
     }
 
     SelectQuery selectQuery = standardizeQuery(query);
-    return streamSelectQuery(selectQuery);
+    return streamSelectQuery(selectQuery, false);
   }
 
   /**

--- a/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
+++ b/src/main/java/org/verdictdb/coordinator/SelectQueryCoordinator.java
@@ -112,7 +112,7 @@ public class SelectQueryCoordinator implements Coordinator {
    * The input is assumed to have been standardized.
    */
   public ExecutionResultReader process(SelectQuery selectQuery) throws VerdictDBException {
-    return process(selectQuery, null);
+    return process(selectQuery, null, false);
   }
 
   public ExecutionResultReader process(
@@ -173,7 +173,7 @@ public class SelectQueryCoordinator implements Coordinator {
     return reader;
   }
 
-  private ExecutionResultReader startOriginalQuery(SelectQuery selectQuery) {
+  private ExecutionResultReader startOriginalQuery(SelectQuery selectQuery) throws VerdictDBException {
     ExecutionInfoToken token = ExecutionInfoToken.empty();
     ExecutionTokenQueue queue = new ExecutionTokenQueue();
     token.setKeyValue("queryResult", conn.execute(selectQuery));

--- a/src/main/java/org/verdictdb/coordinator/ShouldProcessWithOriginalDecider.java
+++ b/src/main/java/org/verdictdb/coordinator/ShouldProcessWithOriginalDecider.java
@@ -13,6 +13,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+package org.verdictdb.coordinator;
+
 import java.util.List;
 
 import com.google.common.base.Optional;
@@ -26,8 +28,8 @@ import org.verdictdb.core.scrambling.ScrambleMeta;
 import org.verdictdb.core.scrambling.ScrambleMetaSet;
 
 public class ShouldProcessWithOriginalDecider {
-  ScrambleMetaSet metaset;
-  float ratioToUseOriginalAfter = -1;
+  private ScrambleMetaSet metaset;
+  private float ratioToUseOriginalAfter = -1;
 
   public ShouldProcessWithOriginalDecider(SelectQuery selectQuery, ScrambleMetaSet metaset) {
     Optional<ConstantColumn> useOriginalAfter = selectQuery.getUseOriginalAfter();

--- a/src/main/java/org/verdictdb/coordinator/ShouldProcessWithOriginalDecider.java
+++ b/src/main/java/org/verdictdb/coordinator/ShouldProcessWithOriginalDecider.java
@@ -1,0 +1,88 @@
+/*
+ *    Copyright 2019 University of Michigan
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+import java.util.List;
+
+import com.google.common.base.Optional;
+
+import org.verdictdb.VerdictSingleResult;
+import org.verdictdb.core.querying.ola.Dimension;
+import org.verdictdb.core.querying.ola.HyperTableCube;
+import org.verdictdb.core.sqlobject.SelectQuery;
+import org.verdictdb.core.sqlobject.ConstantColumn;
+import org.verdictdb.core.scrambling.ScrambleMeta;
+import org.verdictdb.core.scrambling.ScrambleMetaSet;
+
+public class ShouldProcessWithOriginalDecider {
+  ScrambleMetaSet metaset;
+  float ratioToUseOriginalAfter = -1;
+
+  public ShouldProcessWithOriginalDecider(SelectQuery selectQuery, ScrambleMetaSet metaset) {
+    Optional<ConstantColumn> useOriginalAfter = selectQuery.getUseOriginalAfter();
+    if (useOriginalAfter.isPresent()) {
+      ratioToUseOriginalAfter = (float) useOriginalAfter.get().getValue();
+    }
+
+    this.metaset = metaset;
+  }
+
+  public boolean shouldRunOriginal(VerdictSingleResult result) {
+    if (ratioToUseOriginalAfter == -1) {
+      return false;
+    }
+
+    List<HyperTableCube> blocks = result.getMetaData().coveredCubes;
+
+    Double percTableUsed = 0.0;
+    for (HyperTableCube block : blocks) {
+      percTableUsed += percTableUsedForHyperTableCube(block);
+    }
+
+    return percTableUsed >= ratioToUseOriginalAfter;
+  }
+
+
+  private Double percTableUsedForHyperTableCube(HyperTableCube block) {
+    Double result = 1.0;
+    for (Dimension d : block.getDimensions()) {
+      result *= percTableUsedDim(d);
+    }
+
+    return result;
+  }
+
+
+  private Double percTableUsedDim(Dimension dim) {
+    ScrambleMeta scrambleMeta = metaset.getSingleMeta(
+      dim.getSchemaName(), dim.getTableName()
+    );
+
+    Double result = 0.0;
+    int numTiers = scrambleMeta.getNumberOfTiers();
+    for (int i = 0; i < numTiers; i++) {
+      List<Double> tierProbDistrib 
+        = scrambleMeta.getCumulativeDistributionForTier(i);
+
+      Double probSubVal = 0.0;
+      if (dim.getBegin() != 0) {
+        probSubVal = tierProbDistrib.get(dim.getBegin());
+      }
+
+      result += tierProbDistrib.get(dim.getEnd()) - probSubVal;
+    }
+
+    return result;
+  }
+}

--- a/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
@@ -57,7 +57,10 @@ public class ProjectionNode extends CreateTableAsSelectNode {
   @Override
   public ExecutionInfoToken createToken(DbmsQueryResult result) {
     ExecutionInfoToken token = super.createToken(result);
-    result.getMetaData().coveredCubes = coveredCubes;
+
+    if (result != null) {
+      result.getMetaData().coveredCubes = coveredCubes;
+    }
 
     return token;
   }

--- a/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
@@ -17,9 +17,12 @@
 package org.verdictdb.core.querying;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.verdictdb.connection.DbmsQueryResult;
 import org.verdictdb.core.execplan.ExecutionInfoToken;
+import org.verdictdb.core.querying.ola.AggMeta;
+import org.verdictdb.core.querying.ola.HyperTableCube;
 import org.verdictdb.core.sqlobject.SelectQuery;
 import org.verdictdb.core.sqlobject.SqlConvertible;
 import org.verdictdb.exception.VerdictDBException;
@@ -54,7 +57,7 @@ public class ProjectionNode extends CreateTableAsSelectNode {
   @Override
   public ExecutionInfoToken createToken(DbmsQueryResult result) {
     ExecutionInfoToken token = super.createToken(result);
-    result.getMetaData().coveredCubes = coveredCubes
+    result.getMetaData().coveredCubes = coveredCubes;
 
     return token;
   }

--- a/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
@@ -46,9 +46,11 @@ public class ProjectionNode extends CreateTableAsSelectNode {
 
   @Override
   public SqlConvertible createQuery(List<ExecutionInfoToken> tokens) throws VerdictDBException {
-    ExecutionInfoToken token = tokens.get(0);
-    if (token.containsKey("aggMeta")) {
-      coveredCubes.addAll(((AggMeta) token.getValue("aggMeta")).getCubes());
+    if (!tokens.isEmpty()) {
+      ExecutionInfoToken token = tokens.get(0);
+      if (token.containsKey("aggMeta")) {
+        coveredCubes.addAll(((AggMeta) token.getValue("aggMeta")).getCubes());
+      }
     }
 
     return super.createQuery(tokens);

--- a/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
@@ -31,7 +31,7 @@ public class ProjectionNode extends CreateTableAsSelectNode {
 
   private static final long serialVersionUID = 3168447303333633662L;
 
-  private List<HyperTableCube> coveredCubes = new ArrayList<>();
+  protected List<HyperTableCube> coveredCubes = new ArrayList<>();
 
   public ProjectionNode(IdCreator namer, SelectQuery query) {
     super(namer, query);
@@ -51,7 +51,7 @@ public class ProjectionNode extends CreateTableAsSelectNode {
       if (token.containsKey("aggMeta")) {
         coveredCubes.addAll(((AggMeta) token.getValue("aggMeta")).getCubes());
       } else if (token.containsKey("coveredCubes")) {
-        coveredCubes.addAll(token.getValue("coveredCubes"));
+        coveredCubes.addAll((List<HyperTableCube>) token.getValue("coveredCubes"));
       }
     }
 

--- a/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
@@ -50,6 +50,8 @@ public class ProjectionNode extends CreateTableAsSelectNode {
       ExecutionInfoToken token = tokens.get(0);
       if (token.containsKey("aggMeta")) {
         coveredCubes.addAll(((AggMeta) token.getValue("aggMeta")).getCubes());
+      } else if (token.containsKey("coveredCubes")) {
+        coveredCubes.addAll(token.getValue("coveredCubes"));
       }
     }
 
@@ -60,9 +62,7 @@ public class ProjectionNode extends CreateTableAsSelectNode {
   public ExecutionInfoToken createToken(DbmsQueryResult result) {
     ExecutionInfoToken token = super.createToken(result);
 
-    if (result != null) {
-      result.getMetaData().coveredCubes = coveredCubes;
-    }
+    token.setKeyValue("coveredCubes", coveredCubes);
 
     return token;
   }

--- a/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ProjectionNode.java
@@ -28,6 +28,8 @@ public class ProjectionNode extends CreateTableAsSelectNode {
 
   private static final long serialVersionUID = 3168447303333633662L;
 
+  private List<HyperTableCube> coveredCubes = new ArrayList<>();
+
   public ProjectionNode(IdCreator namer, SelectQuery query) {
     super(namer, query);
   }
@@ -41,12 +43,20 @@ public class ProjectionNode extends CreateTableAsSelectNode {
 
   @Override
   public SqlConvertible createQuery(List<ExecutionInfoToken> tokens) throws VerdictDBException {
+    ExecutionInfoToken token = tokens.get(0);
+    if (token.containsKey("aggMeta")) {
+      coveredCubes.addAll(((AggMeta) token.getValue("aggMeta")).getCubes());
+    }
+
     return super.createQuery(tokens);
   }
 
   @Override
   public ExecutionInfoToken createToken(DbmsQueryResult result) {
-    return super.createToken(result);
+    ExecutionInfoToken token = super.createToken(result);
+    result.getMetaData().coveredCubes = coveredCubes
+
+    return token;
   }
 
   @Override

--- a/src/main/java/org/verdictdb/core/querying/ola/SelectAsyncAggExecutionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ola/SelectAsyncAggExecutionNode.java
@@ -184,6 +184,8 @@ public class SelectAsyncAggExecutionNode extends AsyncAggExecutionNode {
   @Override
   public ExecutionInfoToken createToken(DbmsQueryResult result) {
     ExecutionInfoToken token = super.createToken(result);
+    result.getMetaData().coveredCubes = coveredCubes;
+
     token.setKeyValue("queryResult", dbmsQueryResult);
 
     // Addition check that the query is a query contains Asterisk column that without asyncAggExecutionNode.

--- a/src/main/java/org/verdictdb/core/querying/ola/SelectAsyncAggExecutionNode.java
+++ b/src/main/java/org/verdictdb/core/querying/ola/SelectAsyncAggExecutionNode.java
@@ -184,7 +184,10 @@ public class SelectAsyncAggExecutionNode extends AsyncAggExecutionNode {
   @Override
   public ExecutionInfoToken createToken(DbmsQueryResult result) {
     ExecutionInfoToken token = super.createToken(result);
-    result.getMetaData().coveredCubes = coveredCubes;
+
+    if (result != null) {
+      result.getMetaData().coveredCubes = coveredCubes;
+    }
 
     token.setKeyValue("queryResult", dbmsQueryResult);
 

--- a/src/main/java/org/verdictdb/core/sqlobject/SelectQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/SelectQuery.java
@@ -87,6 +87,8 @@ public class SelectQuery extends AbstractRelation implements SqlConvertible {
 
   Optional<UnnamedColumn> limit = Optional.absent();
 
+  Optional<UnnamedColumn> useOriginalAfter = Optional.absent();
+
   //  Optional<String> attribute = Optional.absent();
 
   /**
@@ -162,6 +164,10 @@ public class SelectQuery extends AbstractRelation implements SqlConvertible {
     this.limit = Optional.of(limit);
   }
 
+  public void addUseOriginalAfter(UnnamedColumn useOrigAfter) {
+    useOriginalAfter = Optional.of(useOrigAfter);
+  }
+
   public void addOrderby(List<OrderbyAttribute> columns) {
     orderby.addAll(columns);
   }
@@ -194,6 +200,10 @@ public class SelectQuery extends AbstractRelation implements SqlConvertible {
     this.selectList = new ArrayList<>();
   }
 
+  public void clearUseOriginalAfter() {
+    this.useOriginalAfter = Optional.absent();
+  }
+
   public List<SelectItem> getSelectList() {
     return selectList;
   }
@@ -220,6 +230,10 @@ public class SelectQuery extends AbstractRelation implements SqlConvertible {
 
   public List<OrderbyAttribute> getOrderby() {
     return orderby;
+  }
+
+  public Optional<UnnamedColumn> getUseOriginalAfter() {
+    return useOriginalAfter;
   }
 
   @Override

--- a/src/main/java/org/verdictdb/core/sqlobject/SelectQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/SelectQuery.java
@@ -87,7 +87,7 @@ public class SelectQuery extends AbstractRelation implements SqlConvertible {
 
   Optional<UnnamedColumn> limit = Optional.absent();
 
-  Optional<UnnamedColumn> useOriginalAfter = Optional.absent();
+  Optional<ConstantColumn> useOriginalAfter = Optional.absent();
 
   //  Optional<String> attribute = Optional.absent();
 
@@ -164,7 +164,7 @@ public class SelectQuery extends AbstractRelation implements SqlConvertible {
     this.limit = Optional.of(limit);
   }
 
-  public void addUseOriginalAfter(UnnamedColumn useOrigAfter) {
+  public void addUseOriginalAfter(ConstantColumn useOrigAfter) {
     useOriginalAfter = Optional.of(useOrigAfter);
   }
 
@@ -232,7 +232,7 @@ public class SelectQuery extends AbstractRelation implements SqlConvertible {
     return orderby;
   }
 
-  public Optional<UnnamedColumn> getUseOriginalAfter() {
+  public Optional<ConstantColumn> getUseOriginalAfter() {
     return useOriginalAfter;
   }
 

--- a/src/main/java/org/verdictdb/sqlreader/RelationGen.java
+++ b/src/main/java/org/verdictdb/sqlreader/RelationGen.java
@@ -69,6 +69,12 @@ public class RelationGen extends VerdictSQLParserBaseVisitor<AbstractRelation> {
     if (ctx.limit_clause() != null) {
       sel.addLimit(ConstantColumn.valueOf(ctx.limit_clause().number().getText()));
     }
+
+    if (ctx.use_original_after_clause() != null) {
+      float useOrigAfterVal = ctx.use_original_after_clause().number().getText();
+      sel.addUseOriginalAfter(useOrigAfterVal);
+    }
+    
     return sel;
   }
 

--- a/src/main/java/org/verdictdb/sqlreader/RelationGen.java
+++ b/src/main/java/org/verdictdb/sqlreader/RelationGen.java
@@ -71,8 +71,11 @@ public class RelationGen extends VerdictSQLParserBaseVisitor<AbstractRelation> {
     }
 
     if (ctx.use_original_after_clause() != null) {
-      float useOrigAfterVal = ctx.use_original_after_clause().number().getText();
-      sel.addUseOriginalAfter(useOrigAfterVal);
+      String useOrigAfterVal = ctx.use_original_after_clause().number().getText();
+      
+      sel.addUseOriginalAfter(
+        ConstantColumn.valueOf(Float.parseFloat(useOrigAfterVal))
+      );
     }
     
     return sel;


### PR DESCRIPTION
This pull request, almost finished, adds support for using an USE_ORIGINAL_AFTER clause at the end of a SELECT query.  The clause takes a real valued number in [0, 1] as an argument.  Then, writing a query like

```
SELECT ... FROM ... USE_ORIGINAL_AFTER k
```

for `k \in [0, 1]` will cause verdict to use scrambles to approximate the query until k percent of the rows of the original table has been used for computation.  Once k percent of all tuples in the original table have been used, verdict will abort the approximate query and simply run the original query in its stead.

This pull request requires more unit tests to be written in order to be merged into master.