### PR TITLE
Update CreateSchemaQuery.java

### DIFF
--- a/src/main/java/org/verdictdb/core/sqlobject/CreateSchemaQuery.java
+++ b/src/main/java/org/verdictdb/core/sqlobject/CreateSchemaQuery.java
@@ -26,10 +26,14 @@ public class CreateSchemaQuery implements SqlConvertible {
 
   public CreateSchemaQuery(String schemaName) {
     this.schemaName = schemaName;
+    //Added by Sofia 3-15-2019
+    ifNotExists=true;
   }
 
   public String getSchemaName() {
     return schemaName;
+    
+      
   }
 
   public boolean isIfNotExists() {


### PR DESCRIPTION
When you try to execute the 2 VerdictDB.sql commands back to back :
getting the runtime error:
org.verdictdb.exception.VerdictDBDbmsException: Issued the following query: create schema verdictdbtemp
org.apache.hadoop.hive.metastore.api.AlreadyExistsException: Database verdictdbtemp already exists;

    at org.verdictdb.connection.SparkConnection.executeSingle(SparkConnection.java:166)
    at org.verdictdb.connection.SparkConnection.execute(SparkConnection.java:148)
at org.verdictdb.connection.CachedDbmsConnection.execute(CachedDbmsConnection.java:49)
    at org.verdictdb.connection.DbmsConnection.execute(DbmsConnection.java:41)
    at org.verdictdb.coordinator.SelectQueryCoordinator.process(SelectQueryCoordinator.java:128)
    
This is because: createSchema does not use `IF NOT EXISTS` hence causing the error. 

Fixed this problem in CreateSchemaQuery() constructor